### PR TITLE
feat(i18n): add TypeScript support to translation keys

### DIFF
--- a/apps/web/src/react-i18next.d.ts
+++ b/apps/web/src/react-i18next.d.ts
@@ -1,0 +1,20 @@
+import { translationResources } from "./i18n";
+import commonTranslations from "../public/locales/en/common.json";
+import authTranslations from "../public/locales/en/auth.json";
+import homeTranslations from "../public/locales/en/home.json";
+import messagesTranslations from "../public/locales/en/messages.json";
+import navigationTranslations from "../public/locales/en/navigation.json";
+
+export const translationResources = {
+  common: commonTranslations,
+  auth: authTranslations,
+  home: homeTranslations,
+  messages: messagesTranslations,
+  navigation: navigationTranslations
+}
+
+declare module "react-i18next" {
+  export interface CustomTypeOptions {
+    resources: typeof translationResources
+  }
+}


### PR DESCRIPTION
Developers will now get TypeScript features such as auto-completion when translating texts. The suggestions are based on the English translation file.
![image](https://user-images.githubusercontent.com/38920928/182479629-1588699c-f509-4d6e-8736-a88a8e861c2e.png)
